### PR TITLE
static build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "geos-src/source"]
+	path = geos-src/source
+	url = https://github.com/libgeos/geos

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ build = "build.rs"
 
 [dependencies]
 libc = "~0.2"
+link-cplusplus = { version = "1.0", optional = true }
+geos-src = { path = "./geos-src", version = "0.1.0", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3"
@@ -28,3 +30,4 @@ default = []
 v3_6_0 = []
 v3_7_0 = ["v3_6_0"]
 v3_8_0 = ["v3_7_0"]
+static = ["geos-src", "link-cplusplus"]

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,10 @@ fn main() {
     let lib = "geos_c";
 
     if std::env::var("CARGO_FEATURE_STATIC").is_ok() {
-        let geos_lib = std::env::var("DEP_GEOSSRC_LIB").unwrap();
         let geos_path = std::env::var("DEP_GEOSSRC_SEARCH").unwrap();
 
-        println!("cargo:rustc-link-lib=static={}", geos_lib);
+        println!("cargo:rustc-link-lib=static=geos_c");
+        println!("cargo:rustc-link-lib=static=geos");
         println!("cargo:rustc-link-search=native={}", geos_path);
         println!("cargo:includedir={}/include", geos_path)
     } else {

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,19 @@ extern crate pkg_config;
 fn main() {
     let lib = "geos_c";
 
-    match pkg_config::Config::new().probe(lib) {
-        Ok(_) => {}
-        Err(_) => {
-            println!("cargo:rustc-link-lib=dylib={}", lib);
+    if std::env::var("CARGO_FEATURE_STATIC").is_ok() {
+        let geos_lib = std::env::var("DEP_GEOSSRC_LIB").unwrap();
+        let geos_path = std::env::var("DEP_GEOSSRC_SEARCH").unwrap();
+
+        println!("cargo:rustc-link-lib=static={}", geos_lib);
+        println!("cargo:rustc-link-search=native={}", geos_path);
+        println!("cargo:includedir={}/include", geos_path)
+    } else {
+        match pkg_config::Config::new().probe(lib) {
+            Ok(_) => {}
+            Err(_) => {
+                println!("cargo:rustc-link-lib=dylib={}", lib);
+            }
         }
     }
 

--- a/geos-src/Cargo.toml
+++ b/geos-src/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[build-dependencies]
 cmake = "0.1.45"

--- a/geos-src/Cargo.toml
+++ b/geos-src/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "geos-src"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cmake = "0.1.45"

--- a/geos-src/Cargo.toml
+++ b/geos-src/Cargo.toml
@@ -2,8 +2,9 @@
 name = "geos-src"
 version = "0.1.0"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+links = "geossrc"
+build = "build.rs"
+authors = ["Gaute Hope <eg@gaute.vetsj.com>"]
 
 [build-dependencies]
 cmake = "0.1.45"

--- a/geos-src/build.rs
+++ b/geos-src/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let mut libgeos_config = cmake::Config::new("source");
+    libgeos_config
+        .define("BUILD_BENCHMARKS", "OFF")
+        .define("BUILD_TESTING", "OFF")
+        .define("BUILD_DOCUMENTATION", "OFF")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .profile("Release");
+
+    let libgeos = libgeos_config.build();
+
+    println!("cargo:lib=geos_c");
+
+    let search_path = format!("{}/lib", libgeos.display());
+    assert!(std::path::Path::new(&search_path).exists());
+    println!("cargo:search={}", search_path);
+}

--- a/geos-src/build.rs
+++ b/geos-src/build.rs
@@ -12,6 +12,7 @@ fn main() {
     let libgeos = libgeos_config.build();
 
     println!("cargo:lib=geos_c");
+    println!("cargo:lib=geos");
 
     let search_path = format!("{}/lib", libgeos.display());
     assert!(std::path::Path::new(&search_path).exists());

--- a/geos-src/src/lib.rs
+++ b/geos-src/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/geos-src/src/lib.rs
+++ b/geos-src/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 
 extern crate libc;
 
+#[cfg(feature = "static")]
+extern crate link_cplusplus;
+
 pub use functions::*;
 pub use types::*;
 


### PR DESCRIPTION
Add `static` feature flag as discussed in #20. Builds and tests fine. libgeos version is 3.9.1. 

> To build make sure that submodules are updated and inited: `git submodule update --init`.

- [ ] Remember to add `static` flag to geos (https://github.com/georust/geos/issues/94)

```
❯ ldd libgeos_sys.so
        linux-vdso.so.1 (0x00007fff3c773000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fc515d37000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fc515b1f000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fc515917000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc5156f8000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fc51535a000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fc515156000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc514d65000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fc516470000)
```

## Motivation

* Allows dependent crates to be built into python packages supporting the manywheels spec (making them easier to distribute)
* Allows easier compilation of geos-sys without needing libgeos installed on the system
* Allows easier distribution of binaries / libs without needing same version of libgeos
* Can use a specific / and same version of libgeos 